### PR TITLE
[ENH] Obsolete merchant sign service methods with typo, create solution dictionary

### DIFF
--- a/src/Signicat.Express.SDK.sln.DotSettings
+++ b/src/Signicat.Express.SDK.sln.DotSettings
@@ -1,2 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addons/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addons/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pades/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Signicat/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Signicat.Express.SDK/Services/MerchantSign/IMerchantSignService.cs
+++ b/src/Signicat.Express.SDK/Services/MerchantSign/IMerchantSignService.cs
@@ -26,6 +26,7 @@ namespace Signicat.Express.MerchantSign
         /// </summary>
         /// <param name="transactionId"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete. Please use GetTransaction instead.")]
         MerchantSignTransaction GetTransation(Guid transactionId);
 
         /// <summary>
@@ -33,7 +34,22 @@ namespace Signicat.Express.MerchantSign
         /// </summary>
         /// <param name="transactionId"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete. Please use GetTransactionAsync instead.")]
         Task<MerchantSignTransaction> GetTransationAsync(Guid transactionId);
+
+        /// <summary>
+        /// Retrieves a single transaction.
+        /// </summary>
+        /// <param name="transactionId"></param>
+        /// <returns></returns>
+        MerchantSignTransaction GetTransaction(Guid transactionId);
+
+        /// <summary>
+        /// Retrieves a single transaction.
+        /// </summary>
+        /// <param name="transactionId"></param>
+        /// <returns></returns>
+        Task<MerchantSignTransaction> GetTransactionAsync(Guid transactionId);
 
         /// <summary>
         /// Returns a list of transactions.

--- a/src/Signicat.Express.SDK/Services/MerchantSign/MerchantSignService.cs
+++ b/src/Signicat.Express.SDK/Services/MerchantSign/MerchantSignService.cs
@@ -19,7 +19,7 @@ namespace Signicat.Express.MerchantSign
             : base(clientId, clientSecret, scopes)
         {
         }
-        
+
         public MerchantSignService(string clientId, string clientSecret, IEnumerable<OAuthScope> scopes)
             : base(clientId, clientSecret, scopes)
         {
@@ -34,7 +34,7 @@ namespace Signicat.Express.MerchantSign
         {
             return Post<SignResponse>($"{Urls.MerchantSign}/signature", signRequest);
         }
-        
+
         /// <summary>
         /// Creates a new merchant signature.
         /// </summary>
@@ -50,17 +50,39 @@ namespace Signicat.Express.MerchantSign
         /// </summary>
         /// <param name="transactionId"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete. Please use GetTransaction instead.")]
         public MerchantSignTransaction GetTransation(Guid transactionId)
         {
-            return Get<MerchantSignTransaction>($"{Urls.MerchantSign}/signature/{transactionId}");
+            return GetTransaction(transactionId);
         }
-        
+
         /// <summary>
         /// Retrieves a single transaction.
         /// </summary>
         /// <param name="transactionId"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete. Please use GetTransactionAsync instead.")]
         public async Task<MerchantSignTransaction> GetTransationAsync(Guid transactionId)
+        {
+            return await GetTransactionAsync(transactionId);
+        }
+
+        /// <summary>
+        /// Retrieves a single transaction.
+        /// </summary>
+        /// <param name="transactionId"></param>
+        /// <returns></returns>
+        public MerchantSignTransaction GetTransaction(Guid transactionId)
+        {
+            return Get<MerchantSignTransaction>($"{Urls.MerchantSign}/signature/{transactionId}");
+        }
+
+        /// <summary>
+        /// Retrieves a single transaction.
+        /// </summary>
+        /// <param name="transactionId"></param>
+        /// <returns></returns>
+        public async Task<MerchantSignTransaction> GetTransactionAsync(Guid transactionId)
         {
             return await GetAsync<MerchantSignTransaction>($"{Urls.MerchantSign}/signature/{transactionId}");
         }
@@ -84,10 +106,10 @@ namespace Signicat.Express.MerchantSign
                     {"fromDate", fromDate},
                     {"toDate", toDate}
                 });
-            
+
             return Get<IList<MerchantSignTransaction>>(url);
         }
-        
+
         /// <summary>
         /// Returns a list of transactions.
         /// </summary>
@@ -107,7 +129,7 @@ namespace Signicat.Express.MerchantSign
                     {"fromDate", fromDate},
                     {"toDate", toDate}
                 });
-            
+
             return await GetAsync<IList<MerchantSignTransaction>>(url);
         }
 
@@ -120,7 +142,7 @@ namespace Signicat.Express.MerchantSign
         {
             return GetFile($"{Urls.MerchantSign}/pades/{signedDocumentId}");
         }
-        
+
         /// <summary>
         /// Retrieve PAdES of signed PDF file.
         /// </summary>


### PR DESCRIPTION
Hello!

Here are some minor changes:

1. Obsolete merchant signing service methods that contain typo (due to breaking change nature, I leave the removal of these methods to you, based on your policy)
2. Added words: `Signicat` and `Pades` to solution wide dictionary


Thank you and best regards,
dex